### PR TITLE
pay: a Stripe block with both workflows on one page

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Each block exposes a `connect(app)` function that registers routes, seeds data, 
 
 **hora** is Vedic planetary hours, computed in the browser from the local sunrise and sunset. It is the block that shows what "self-contained" can stretch to: it brings its own head, its own Tailwind stylesheet and its own document, so none of the app-wide chrome reaches it. It serves `/hora` here and the whole of [sankalpa.sh](https://sankalpa.sh).
 
+**pay** sells things with Stripe, through [faststripe](https://github.com/AnswerDotAI/faststripe). It carries a catalogue, two Checkout flows and a signed webhook, and it needs nothing set up in the Stripe dashboard first: prices go inline on each Checkout Session. `/pay` prices a desktop app at $200 paid once and a hosted plan at $19 a month, so both Stripe workflows sit on one page. See [Payments](#payments).
+
 **blog** is a full publishing block. Posts are seeded from Markdown files with YAML frontmatter. The list page uses a newspaper-style featured/sidebar/grid layout. Post detail pages support single-column or two-column newspaper layout, set per-post via `layout: newspaper` in the frontmatter. Code blocks never split across columns. To force a column break at a specific point in a post, add:
 
 ````md
@@ -59,7 +61,9 @@ lego/
 │   ├── app.py           # wire up blocks, scheduled jobs
 │   ├── auth/            # auth block
 │   ├── blog/            # blog block
+│   ├── dash/            # dashboards block
 │   ├── hora/            # hora block — also serves sankalpa.sh
+│   ├── pay/             # stripe block
 │   └── core/            # config, cache, logging, backups, UI
 ├── data/
 │   ├── db/              # SQLite databases
@@ -147,6 +151,66 @@ RouteOverrides.lgn = "/login"
 RouteOverrides.home = "/dashboard"
 RouteOverrides.skip += ["/public"]
 ```
+
+## Payments
+
+The pay block talks to Stripe through [faststripe](https://github.com/AnswerDotAI/faststripe). Five routes:
+
+| route | purpose |
+|---|---|
+| `GET /pay` | the catalogue, and what the signed-in reader already owns |
+| `POST /pay/buy/{key}` | opens a Checkout Session and sends the buyer to Stripe |
+| `GET /pay/done` | reads the session the buyer came back with, writes the order, shows a receipt |
+| `POST /pay/portal` | sends a subscriber to Stripe's billing portal |
+| `POST /pay/hook` | signed webhook: payment and subscription events |
+
+### Without a key
+
+With no `STRIPE_SECRET_KEY` set, the block runs in sandbox. Buying writes the order Stripe would have sent back straight into `data/db/pay.db`. Pages, receipts and the owned list all work, so you can style the flow before you have an account.
+
+### With a test key
+
+1. Create a Stripe account and copy the secret key from the [test dashboard](https://dashboard.stripe.com/test/apikeys). It starts with `sk_test_`.
+2. Put it in `.env` as `STRIPE_SECRET_KEY=sk_test_...`
+3. Restart. Buying now opens Stripe's hosted Checkout. Card `4242 4242 4242 4242`, any future expiry, any CVC.
+
+Stripe sends the buyer back to `/pay/done?sid=...` and the block reads that session to write the order. Recording a sale needs no webhook, which is what makes a bare test key enough to see the whole flow.
+
+### Webhooks
+
+Subscriptions change while nobody is on the site: renewals, failed cards, cancellations. That is what the webhook is for.
+
+```bash
+stripe listen --forward-to localhost:5001/pay/hook
+```
+
+The CLI prints a signing secret. Put it in `.env` as `STRIPE_WEBHOOK_SECRET` and restart. In production, add the endpoint at `{DOMAIN}/pay/hook` in the Stripe dashboard and copy its secret from there. `/pay/hook` sits in the block's skip list so it bypasses auth; `parse_webhook` checks the signature and the route answers 400 when it fails.
+
+### Going live
+
+Swap the test key for the live one and add the live webhook endpoint. Set `STRIPE_CURRENCY` if you do not price in dollars.
+
+| env var | default | purpose |
+|---|---|---|
+| `STRIPE_SECRET_KEY` | `''` | `sk_test_…` or `sk_live_…`. Empty means sandbox |
+| `STRIPE_WEBHOOK_SECRET` | `''` | `whsec_…`, from `stripe listen` or the dashboard endpoint |
+| `STRIPE_PUBLISHABLE_KEY` | `''` | only needed if you add client-side Stripe.js |
+| `STRIPE_CURRENCY` | `usd` | three-letter code the catalogue prices in |
+
+### The catalogue
+
+`CATALOG` in `lego/pay/cfg.py` is the whole product list. An `interval` is what makes an item a subscription:
+
+```python
+AttrDict(key='cloud', nm='Lego Cloud', kind='Subscription', mode='subscription',
+         amount=1900, interval='month', blurb='...', perks=[...], cta='Subscribe at $19/mo')
+```
+
+`amount` is in cents. Because prices go inline on the Checkout Session, changing a number here changes what Stripe charges on the next click, with no product to edit in the dashboard.
+
+### Carrying it to another app
+
+Copy `lego/pay/` across, add `p.connect(app)` before auth connects, and edit `CATALOG`. The block owns its table, its stylesheet and its routes. All it borrows from core is `base()`, `RouteOverrides`, and the per-thread database helper.
 
 ## Extensions
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Each block exposes a `connect(app)` function that registers routes, seeds data, 
 
 **hora** is Vedic planetary hours, computed in the browser from the local sunrise and sunset. It is the block that shows what "self-contained" can stretch to: it brings its own head, its own Tailwind stylesheet and its own document, so none of the app-wide chrome reaches it. It serves `/hora` here and the whole of [sankalpa.sh](https://sankalpa.sh).
 
-**pay** sells things with Stripe, through [faststripe](https://github.com/AnswerDotAI/faststripe). It carries a catalogue, two Checkout flows and a signed webhook, and it needs nothing set up in the Stripe dashboard first: prices go inline on each Checkout Session. `/pay` prices a desktop app at $200 paid once and a hosted plan at $19 a month, so both Stripe workflows sit on one page. See [Payments](#payments).
+**pay** sells things with Stripe, through [faststripe](https://github.com/AnswerDotAI/faststripe). It brings a catalogue, two Checkout flows, and a signed webhook. Nothing has to exist in the Stripe dashboard first, because prices go inline on each Checkout Session. `/pay` prices a desktop app at $200 paid once, and a hosted plan at $19 a month. See [Payments](#payments).
 
 **blog** is a full publishing block. Posts are seeded from Markdown files with YAML frontmatter. The list page uses a newspaper-style featured/sidebar/grid layout. Post detail pages support single-column or two-column newspaper layout, set per-post via `layout: newspaper` in the frontmatter. Code blocks never split across columns. To force a column break at a specific point in a post, add:
 
@@ -166,7 +166,7 @@ The pay block talks to Stripe through [faststripe](https://github.com/AnswerDotA
 
 ### Without a key
 
-With no `STRIPE_SECRET_KEY` set, the block runs in sandbox. Buying writes the order Stripe would have sent back straight into `data/db/pay.db`. Pages, receipts and the owned list all work, so you can style the flow before you have an account.
+With no `STRIPE_SECRET_KEY` set, the block runs in sandbox. Buying writes the order Stripe would have sent back straight into `data/db/pay.db`. Pages, receipts and the owned list all work. You can style the whole flow before you have an account.
 
 ### With a test key
 
@@ -184,7 +184,7 @@ Subscriptions change while nobody is on the site: renewals, failed cards, cancel
 stripe listen --forward-to localhost:5001/pay/hook
 ```
 
-The CLI prints a signing secret. Put it in `.env` as `STRIPE_WEBHOOK_SECRET` and restart. In production, add the endpoint at `{DOMAIN}/pay/hook` in the Stripe dashboard and copy its secret from there. `/pay/hook` sits in the block's skip list so it bypasses auth; `parse_webhook` checks the signature and the route answers 400 when it fails.
+The CLI prints a signing secret. Put it in `.env` as `STRIPE_WEBHOOK_SECRET` and restart. In production, add the endpoint at `{DOMAIN}/pay/hook` in the Stripe dashboard and copy its secret from there. `/pay/hook` bypasses auth because it is in the block's skip list. `parse_webhook` checks the signature. A bad one gets a 400.
 
 ### Going live
 
@@ -206,7 +206,7 @@ AttrDict(key='cloud', nm='Lego Cloud', kind='Subscription', mode='subscription',
          amount=1900, interval='month', blurb='...', perks=[...], cta='Subscribe at $19/mo')
 ```
 
-`amount` is in cents. Because prices go inline on the Checkout Session, changing a number here changes what Stripe charges on the next click, with no product to edit in the dashboard.
+`amount` is in cents. Prices go inline on the Checkout Session, so change a number here and Stripe charges the new one on the next click. There is no product to edit in the dashboard.
 
 ### Carrying it to another app
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -560,25 +560,25 @@ both workflows: a one-off payment and a monthly subscription.
 | `POST /pay/hook` | signed webhook |
 
 **Catalogue.** `CATALOG` in `cfg.py`, one `AttrDict` per item. `amount` is in cents and an
-`interval` makes the item a subscription. Prices are built inline on the Checkout Session
-via `line_items[].price_data`, so no product has to exist in the Stripe dashboard and a
-price change takes effect on the next click.
+`interval` makes the item a subscription. Prices go inline on the Checkout Session, in
+`line_items[].price_data`. No product has to exist in the Stripe dashboard, and a price
+change takes effect on the next click.
 
 **Sandbox.** With `STRIPE_SECRET_KEY` unset, `buy()` writes the row Stripe would have
 returned and redirects to the receipt. Every page works with no account, and the pricing
 page says so. Set a key and the same routes hit Stripe.
 
 **Settling.** `/pay/done` reads the Checkout Session by id rather than waiting for the
-webhook, so a bare test key is enough to record a sale. The webhook writes the same row
-again and is what catches renewals and cancellations, which happen with nobody on the site.
-`/pay/hook` is in `Routes.skip`; `parse_webhook` verifies the signature and the route
-answers 400 when it does not match.
+webhook. A bare test key is then enough to record a sale. The webhook writes the same row
+again, and catches the renewals and cancellations that happen with nobody on the site.
+`/pay/hook` is in `Routes.skip`. `parse_webhook` verifies the signature, and a payload that
+fails it gets a 400.
 
 **Async.** faststripe is an async client, so `pay_buy`, `pay_done`, `pay_portal` and
-`pay_hook` are `async def`. Only `pay_index` is sync.
+`pay_hook` are `async def`. `pay_index` is the only plain `def`.
 
 **Env:** `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PUBLISHABLE_KEY`,
-`STRIPE_CURRENCY` (default `usd`). Success and cancel URLs are built from `cfg.domain`, so
+`STRIPE_CURRENCY` (default `usd`). Success and cancel URLs come from `cfg.domain`, so
 `DOMAIN` has to be right in production.
 
 ## Adding a new block

--- a/SKILL.md
+++ b/SKILL.md
@@ -42,6 +42,7 @@ Connect order matters. Auth reads `RouteOverrides.skip` at connect time to build
 # lego/app.py — correct order
 b.connect(lego)   # blog: appends its public routes to skip list
 h.connect(lego)   # hora: likewise
+p.connect(lego)   # pay: likewise
 a.connect(lego)   # auth: always last, reads the complete skip list
 ```
 
@@ -78,6 +79,10 @@ from lego.core.backups import run_backup, clone
 | `CF_ACCESS_KEY_ID` | `''` | Cloudflare R2 access key |
 | `CF_SCRT_ACCESS_KEY` | `''` | Cloudflare R2 secret |
 | `CF_ENDPOINT` | `''` | Cloudflare R2 endpoint |
+| `STRIPE_SECRET_KEY` | `''` | `sk_test_…`/`sk_live_…`; empty runs the pay block in sandbox |
+| `STRIPE_WEBHOOK_SECRET` | `''` | `whsec_…` for `/pay/hook` |
+| `STRIPE_PUBLISHABLE_KEY` | `''` | only for client-side Stripe.js |
+| `STRIPE_CURRENCY` | `usd` | currency the catalogue prices in |
 
 `not_prod()` returns `True` when `MODE != 'production'`. Theme switcher only appears in dev mode.
 
@@ -535,6 +540,46 @@ class assembled from fragments at runtime would be purged.
 same container, same tunnel and same Cloudflare zone as `lego.sankalpa.sh`, with Caddy
 rewriting `/` to `/hora` for that Host. `HORA_DOMAIN` moves it. See *Deployment* in
 `README.md`.
+
+## Pay block (`lego/pay/`)
+
+```python
+import lego.pay as p
+p.connect(lego)   # before auth
+```
+
+Stripe Checkout through [faststripe](https://github.com/AnswerDotAI/faststripe), covering
+both workflows: a one-off payment and a monthly subscription.
+
+| route | purpose |
+|---|---|
+| `GET /pay` | catalogue, plus what the signed-in reader owns |
+| `POST /pay/buy/{key}` | opens a Checkout Session, 303s to Stripe |
+| `GET /pay/done?sid=` | reads the session, writes the order, renders the receipt |
+| `POST /pay/portal` | 303s a subscriber to Stripe's billing portal |
+| `POST /pay/hook` | signed webhook |
+
+**Catalogue.** `CATALOG` in `cfg.py`, one `AttrDict` per item. `amount` is in cents and an
+`interval` makes the item a subscription. Prices are built inline on the Checkout Session
+via `line_items[].price_data`, so no product has to exist in the Stripe dashboard and a
+price change takes effect on the next click.
+
+**Sandbox.** With `STRIPE_SECRET_KEY` unset, `buy()` writes the row Stripe would have
+returned and redirects to the receipt. Every page works with no account, and the pricing
+page says so. Set a key and the same routes hit Stripe.
+
+**Settling.** `/pay/done` reads the Checkout Session by id rather than waiting for the
+webhook, so a bare test key is enough to record a sale. The webhook writes the same row
+again and is what catches renewals and cancellations, which happen with nobody on the site.
+`/pay/hook` is in `Routes.skip`; `parse_webhook` verifies the signature and the route
+answers 400 when it does not match.
+
+**Async.** faststripe is an async client, so `pay_buy`, `pay_done`, `pay_portal` and
+`pay_hook` are `async def`. Only `pay_index` is sync.
+
+**Env:** `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `STRIPE_PUBLISHABLE_KEY`,
+`STRIPE_CURRENCY` (default `usd`). Success and cancel URLs are built from `cfg.domain`, so
+`DOMAIN` has to be right in production.
 
 ## Adding a new block
 

--- a/lego/app.py
+++ b/lego/app.py
@@ -4,7 +4,7 @@ from fasthtml.common import *
 from starlette.middleware import Middleware
 from starlette.middleware.gzip import GZipMiddleware
 from .core import *
-from lego import auth as a, blog as b, dash as d, hora as h
+from lego import auth as a, blog as b, dash as d, hora as h, pay as p
 
 __all__ = ['launch', 'lego']
 
@@ -57,6 +57,7 @@ for _d in ('vendor', 'assets'):
 b.connect(lego)
 d.connect(lego) # dashboards
 h.connect(lego) # hora — also the whole of sankalpa.sh, which Caddy rewrites / to /hora
+p.connect(lego) # pay — stripe checkout, one-off and subscription
 a.connect(lego) # auth needs to be the last to connect. it reads RouteOverrides skip list to skip auth
 
 # optionally add a scheduled backup of data folders

--- a/lego/app.py
+++ b/lego/app.py
@@ -1,5 +1,4 @@
 import os
-from fasthtml.common import Meta, Favicon, Socials, Link, serve, Script, JSONResponse, Div, P
 from fasthtml.common import *
 from starlette.middleware import Middleware
 from starlette.middleware.gzip import GZipMiddleware

--- a/lego/auth/data.py
+++ b/lego/auth/data.py
@@ -181,7 +181,6 @@ class Register(Login):
 
     def __ft__(self, **kwargs):
         err = self.catch()
-        print('err:', err)
         return form(Step.em_ver, self.email) if not err else form(Step.reg, self.email, self.name, err=err)
 
     def catch(self):

--- a/lego/core/icons.py
+++ b/lego/core/icons.py
@@ -6,7 +6,7 @@ __all__ = ['icon_auto', 'icon_toc', 'lc_icon', 'lc_sprites', 'lc_sprite_nms']
 # every lucide icon the app renders (incl. via htmx fragments) must be seeded here
 # so the sprite sheet emitted on full page loads contains all symbols
 _NMS = ('lock', 'log-out', 'moon', 'sun', 'sun-moon', 'palette', 'notebook', 'case-lower', 'triangle-alert',
-        'search', 'circle-help', 'table-2')
+        'search', 'circle-help', 'table-2', 'check', 'monitor', 'cloud', 'credit-card')
 _ALIASES = {'warning': 'triangle-alert'}
 
 class _Nms(set):

--- a/lego/dash/app.py
+++ b/lego/dash/app.py
@@ -1,4 +1,4 @@
-from urllib.parse import quote, urlencode
+from urllib.parse import urlencode
 from fasthtml.common import JSONResponse, RedirectResponse
 from fastcore.xml import Div
 from lego.core import base, not_found, RouteOverrides

--- a/lego/dash/build.py
+++ b/lego/dash/build.py
@@ -19,8 +19,8 @@ category even though the column holding it is an integer on another table.
 from urllib.parse import urlencode, parse_qsl
 from fastcore.all import AttrDict
 from .cfg import cfg
-from .data import DBS, table_names, reflect, rowcount
-from .infer import Spec, roles, _cats, _axes, agg_for, _h, _plural
+from .data import table_names, rowcount
+from .infer import Spec, roles, _cats, _axes, _h, _plural
 
 __all__ = ['KINDS', 'AGGS', 'options', 'compose', 'pins', 'pin_qs', 'wire_pin']
 

--- a/lego/dash/ui.py
+++ b/lego/dash/ui.py
@@ -2,11 +2,11 @@ from urllib.parse import urlencode, quote
 from fastcore.xml import *
 from fasthtml.common import *
 from fastcore.all import timed_cache
-from lego.core import lc_icon, TextT, ButtonT, PresetsT, asset_js, asset_css, vendor_js, Badge, BadgePresetsT
+from lego.core import lc_icon, ButtonT, PresetsT, asset_js, asset_css, vendor_js, Badge
 from .cfg import Routes, cfg
 from .data import DBS, schema, reflect, profile, table_names, rowcount
-from .infer import roles, specs_for_db, specs_for_table, label_col, fmt_of, _h
-from .charts import stats, sparkline, page_rows, row_get, child_rows, child_count, headline, count_rows
+from .infer import roles, specs_for_db, specs_for_table, label_col, _h
+from .charts import sparkline, page_rows, row_get, child_rows, child_count, headline, count_rows
 from .filters import SEP, wire, describe, applies, columns, ops_for, values_for
 from .build import KINDS, AGGS, options, pin_qs, wire_pin
 

--- a/lego/pay/__init__.py
+++ b/lego/pay/__init__.py
@@ -1,0 +1,1 @@
+from .app import connect

--- a/lego/pay/app.py
+++ b/lego/pay/app.py
@@ -1,4 +1,5 @@
 from fasthtml.common import JSONResponse, Redirect
+from fastlite import NotFoundError
 from lego.core import base, not_found, RouteOverrides
 from .cfg import Routes
 from .data import StripeError, StripeSignatureError, apply_hook, buy, item, mine, portal_url, settle, sub_of
@@ -7,7 +8,7 @@ from .ui import pay_head, pricing, receipt
 __all__ = ['connect', 'Routes']
 
 def _page(content, auth, title): return (*base(content, auth, title=title), *pay_head())
-def _pricing(auth, err=None): return _page(pricing(auth, mine(auth), err), auth, 'Pricing')
+def _pricing(auth, err=None): return _page(pricing(mine(auth), err), auth, 'Pricing')
 
 def pay_index(req, auth=None): return _pricing(auth)
 
@@ -21,7 +22,7 @@ async def pay_buy(req, key: str, auth=None):
 async def pay_done(req, sid: str = '', auth=None):
     if not sid: return Redirect(Routes.index)
     try: o = await settle(sid)
-    except (StripeError, StopIteration, KeyError): return not_found()
+    except (StripeError, NotFoundError, StopIteration): return not_found()
     return _page(receipt(o, auth), auth, 'Receipt')
 
 async def pay_portal(req, auth=None):
@@ -32,7 +33,7 @@ async def pay_portal(req, auth=None):
 
 async def pay_hook(req):
     try: t = await apply_hook(req)
-    except (StripeError, StripeSignatureError) as e: return JSONResponse({'error': str(e)}, status_code=400)
+    except (StripeError, StripeSignatureError, ValueError) as e: return JSONResponse({'error': str(e)}, status_code=400)
     return JSONResponse({'received': t})
 
 def connect(app):

--- a/lego/pay/app.py
+++ b/lego/pay/app.py
@@ -1,0 +1,45 @@
+from fasthtml.common import JSONResponse, Redirect
+from lego.core import base, not_found, RouteOverrides
+from .cfg import Routes
+from .data import StripeError, StripeSignatureError, apply_hook, buy, item, mine, portal_url, settle, sub_of
+from .ui import pay_head, pricing, receipt
+
+__all__ = ['connect', 'Routes']
+
+def _page(content, auth, title): return (*base(content, auth, title=title), *pay_head())
+def _pricing(auth, err=None): return _page(pricing(auth, mine(auth), err), auth, 'Pricing')
+
+def pay_index(req, auth=None): return _pricing(auth)
+
+async def pay_buy(req, key: str, auth=None):
+    it = item(key)
+    if not it: return not_found()
+    try: sid, url = await buy(it, auth)
+    except StripeError as e: return _pricing(auth, str(e))
+    return Redirect(url or f'{Routes.done}?sid={sid}')
+
+async def pay_done(req, sid: str = '', auth=None):
+    if not sid: return Redirect(Routes.index)
+    try: o = await settle(sid)
+    except (StripeError, StopIteration, KeyError): return not_found()
+    return _page(receipt(o, auth), auth, 'Receipt')
+
+async def pay_portal(req, auth=None):
+    s = sub_of(mine(auth))
+    if not (s and s['customer']): return Redirect(Routes.index)
+    try: return Redirect(await portal_url(s['customer']))
+    except StripeError as e: return _pricing(auth, str(e))
+
+async def pay_hook(req):
+    try: t = await apply_hook(req)
+    except (StripeError, StripeSignatureError) as e: return JSONResponse({'error': str(e)}, status_code=400)
+    return JSONResponse({'received': t})
+
+def connect(app):
+    RouteOverrides.skip += Routes.skip
+    RouteOverrides.nav = RouteOverrides.nav + [('Pricing', Routes.index, None, False)]
+    app.get(Routes.index)(pay_index)
+    app.get(Routes.done)(pay_done)
+    app.post(Routes.buy)(pay_buy)
+    app.post(Routes.portal)(pay_portal)
+    app.post(Routes.hook)(pay_hook)

--- a/lego/pay/cfg.py
+++ b/lego/pay/cfg.py
@@ -1,0 +1,38 @@
+import os
+from dataclasses import dataclass
+from fastcore.all import L, AttrDict
+
+@dataclass(frozen=True)
+class Routes:
+    index  = '/pay'
+    buy    = '/pay/buy/{key}'
+    done   = '/pay/done'
+    portal = '/pay/portal'
+    hook   = '/pay/hook'
+    skip   = ['/pay', '/pay/done', '/pay/portal', '/pay/hook', r'/pay/buy/.*']
+
+# The names Stripe's own docs and CLI use, so a key copied from the dashboard lands where
+# faststripe already looks for it.
+cfg = AttrDict(scrt     = os.getenv('STRIPE_SECRET_KEY', ''),
+               pub      = os.getenv('STRIPE_PUBLISHABLE_KEY', ''),
+               hook     = os.getenv('STRIPE_WEBHOOK_SECRET', ''),
+               currency = os.getenv('STRIPE_CURRENCY', 'usd'))
+
+# Amounts are in the currency's smallest unit, which is what Stripe takes and what avoids
+# float money. `interval` is what makes an item a subscription rather than a one-off.
+CATALOG = L(
+    AttrDict(key='studio', nm='Lego Studio', kind='Desktop app', mode='payment', amount=20000,
+             blurb='The block editor for macOS and Windows. Pay once, keep the app.',
+             perks=['Signed builds for macOS 13+ and Windows 11',
+                    'One licence, three machines',
+                    'A year of updates; the version you have keeps working after that',
+                    'Runs offline, no account needed'],
+             cta='Buy for $200'),
+    AttrDict(key='cloud', nm='Lego Cloud', kind='Subscription', mode='subscription', amount=1900,
+             interval='month',
+             blurb='Hosted builds and a shared block library, billed monthly.',
+             perks=['Build for macOS and Windows without owning either',
+                    'Shared block library across your team',
+                    'Nightly backups kept for 30 days',
+                    'Cancel from the billing portal, no email needed'],
+             cta='Subscribe at $19/mo'))

--- a/lego/pay/data.py
+++ b/lego/pay/data.py
@@ -1,0 +1,89 @@
+import time
+from fastcore.all import AttrDict, first
+from faststripe.core import StripeApi, StripeError
+from faststripe.core import StripeSignatureError
+from lego.core import cfg as app_cfg, thread_db, get_db_pth, quick_lgr, slug
+from .cfg import Routes, cfg, CATALOG
+
+__all__ = ['orders', 'sapi', 'live', 'item', 'mine', 'sub_of', 'buy', 'settle', 'portal_url', 'apply_hook',
+           'StripeError', 'StripeSignatureError']
+
+info, error, warn = quick_lgr()
+
+def _setup(db, first):
+    if not first: return
+    db.t.orders.create(id=str, user_id=int, email=str, item=str, mode=str, amount=int, currency=str,
+                       status=str, customer=str, sub=str, created_at=float, pk='id', if_not_exists=True,
+                       transform=True)
+    db.t.orders.create_index(['email'], if_not_exists=True)
+
+_db    = thread_db(get_db_pth('pay'), setup=_setup)
+orders = _db.table('orders')
+
+sapi = StripeApi(api_key=cfg.scrt, webhook_key=cfg.hook, publishable_key=cfg.pub)
+
+def live(): return bool(cfg.scrt)
+def item(key): return first(CATALOG, lambda i: i.key == key)
+def mine(auth): return orders(where='email = ?', where_args=[auth['email']], order_by='created_at desc') if auth else []
+def sub_of(rows): return first(rows, lambda o: o['sub'] and o['status'] == 'active')
+
+def _line(it):
+    'A price built inline, so the block needs no products set up in the dashboard first.'
+    p = dict(currency=cfg.currency, unit_amount=it.amount, product_data=dict(name=it.nm, description=it.blurb))
+    if it.get('interval'): p['recurring'] = dict(interval=it.interval)
+    return dict(quantity=1, price_data=p)
+
+def _save(s):
+    'One row per Checkout Session, whichever way it reached us — the return trip or the webhook.'
+    d = dict(id=s.id, user_id=int(s.get('client_reference_id') or 0),
+             email=(s.get('customer_details') or {}).get('email') or s.get('customer_email') or '',
+             item=(s.get('metadata') or {}).get('item', ''), mode=s.get('mode', ''),
+             amount=s.get('amount_total') or 0, currency=s.get('currency') or cfg.currency,
+             status='active' if s.get('subscription') else
+                    ('paid' if s.get('payment_status') == 'paid' else s.get('status', '')),
+             customer=s.get('customer') or '', sub=s.get('subscription') or '',
+             created_at=float(s.get('created') or time.time()))
+    orders.insert(d, replace=True)
+    return d
+
+def _sandbox(it, auth):
+    'No key set: write the row Stripe would have sent back, so the flow is walkable before signup.'
+    return _save(AttrDict(id=f'sandbox_{slug(it.key + str(time.time()))}', mode=it.mode, amount_total=it.amount,
+                          currency=cfg.currency, payment_status='paid', created=time.time(),
+                          subscription=f'sandbox_sub_{it.key}' if it.get('interval') else '',
+                          client_reference_id=str(auth['id']) if auth else '',
+                          customer_email=auth['email'] if auth else 'buyer@example.com',
+                          metadata=dict(item=it.key)))
+
+async def buy(it, auth):
+    'Checkout Session for `it`, or a sandbox order when no key is configured.'
+    if not live(): return _sandbox(it, auth)['id'], None
+    root = app_cfg.domain.rstrip('/')
+    kw = dict(mode=it.mode, line_items=[_line(it)], metadata=dict(item=it.key),
+              success_url=f'{root}{Routes.done}?sid={{CHECKOUT_SESSION_ID}}', cancel_url=f'{root}{Routes.index}')
+    if auth: kw |= dict(customer_email=auth['email'], client_reference_id=str(auth['id']))
+    s = await sapi.v1.checkout.sessions.post(**kw)
+    return s.id, s.url
+
+async def settle(sid):
+    '''Record the session the buyer came back with.
+
+    Webhooks are the source of truth in production, but they need a public URL and a
+    signing secret. Reading the session on return means a fresh test key pays and shows a
+    receipt with neither of those, and the webhook only ever writes the same row again.'''
+    if sid.startswith('sandbox_'): return orders[sid]
+    return _save(await sapi.v1.checkout.sessions.session.get(session=sid))
+
+async def portal_url(customer):
+    s = await sapi.v1.billing_portal.sessions.post(customer=customer,
+                                                   return_url=f'{app_cfg.domain.rstrip("/")}{Routes.index}')
+    return s.url
+
+async def apply_hook(req):
+    evt = await sapi.parse_webhook(req)
+    o = evt.data
+    if evt.type == 'checkout.session.completed': _save(o)
+    elif evt.type.startswith('customer.subscription.'):
+        for r in orders(where='sub = ?', where_args=[o.id]): orders.update(dict(id=r['id'], status=o.status))
+    info(f'stripe hook {evt.type} {o.get("id")}')
+    return evt.type

--- a/lego/pay/data.py
+++ b/lego/pay/data.py
@@ -1,14 +1,13 @@
 import time
 from fastcore.all import AttrDict, first
-from faststripe.core import StripeApi, StripeError
-from faststripe.core import StripeSignatureError
+from faststripe.core import StripeApi, StripeError, StripeSignatureError
 from lego.core import cfg as app_cfg, thread_db, get_db_pth, quick_lgr, slug
 from .cfg import Routes, cfg, CATALOG
 
 __all__ = ['orders', 'sapi', 'live', 'item', 'mine', 'sub_of', 'buy', 'settle', 'portal_url', 'apply_hook',
            'StripeError', 'StripeSignatureError']
 
-info, error, warn = quick_lgr()
+info = quick_lgr()[0]
 
 def _setup(db, first):
     if not first: return
@@ -24,8 +23,10 @@ sapi = StripeApi(api_key=cfg.scrt, webhook_key=cfg.hook, publishable_key=cfg.pub
 
 def live(): return bool(cfg.scrt)
 def item(key): return first(CATALOG, lambda i: i.key == key)
-def mine(auth): return orders(where='email = ?', where_args=[auth['email']], order_by='created_at desc') if auth else []
 def sub_of(rows): return first(rows, lambda o: o['sub'] and o['status'] == 'active')
+def mine(auth):
+    if not auth: return []
+    return orders(where='email = ?', where_args=[auth['email']], order_by='created_at desc')
 
 def _line(it):
     'A price built inline, so the block needs no products set up in the dashboard first.'
@@ -33,15 +34,17 @@ def _line(it):
     if it.get('interval'): p['recurring'] = dict(interval=it.interval)
     return dict(quantity=1, price_data=p)
 
+def _status(s):
+    if s.get('subscription'): return 'active'
+    return 'paid' if s.get('payment_status') == 'paid' else s.get('status', '')
+
 def _save(s):
-    'One row per Checkout Session, whichever way it reached us — the return trip or the webhook.'
+    'One row per Checkout Session, written by the return trip or by the webhook.'
     d = dict(id=s.id, user_id=int(s.get('client_reference_id') or 0),
              email=(s.get('customer_details') or {}).get('email') or s.get('customer_email') or '',
              item=(s.get('metadata') or {}).get('item', ''), mode=s.get('mode', ''),
              amount=s.get('amount_total') or 0, currency=s.get('currency') or cfg.currency,
-             status='active' if s.get('subscription') else
-                    ('paid' if s.get('payment_status') == 'paid' else s.get('status', '')),
-             customer=s.get('customer') or '', sub=s.get('subscription') or '',
+             status=_status(s), customer=s.get('customer') or '', sub=s.get('subscription') or '',
              created_at=float(s.get('created') or time.time()))
     orders.insert(d, replace=True)
     return d
@@ -52,8 +55,7 @@ def _sandbox(it, auth):
                           currency=cfg.currency, payment_status='paid', created=time.time(),
                           subscription=f'sandbox_sub_{it.key}' if it.get('interval') else '',
                           client_reference_id=str(auth['id']) if auth else '',
-                          customer_email=auth['email'] if auth else 'buyer@example.com',
-                          metadata=dict(item=it.key)))
+                          customer_email=auth['email'] if auth else '', metadata=dict(item=it.key)))
 
 async def buy(it, auth):
     'Checkout Session for `it`, or a sandbox order when no key is configured.'
@@ -69,8 +71,8 @@ async def settle(sid):
     '''Record the session the buyer came back with.
 
     Webhooks are the source of truth in production, but they need a public URL and a
-    signing secret. Reading the session on return means a fresh test key pays and shows a
-    receipt with neither of those, and the webhook only ever writes the same row again.'''
+    signing secret. Reading the session on return needs neither, so a fresh test key pays
+    and shows a receipt. The webhook then only ever writes the same row again.'''
     if sid.startswith('sandbox_'): return orders[sid]
     return _save(await sapi.v1.checkout.sessions.session.get(session=sid))
 
@@ -80,6 +82,7 @@ async def portal_url(customer):
     return s.url
 
 async def apply_hook(req):
+    if not req.headers.get('stripe-signature'): raise StripeSignatureError('No signature header')
     evt = await sapi.parse_webhook(req)
     o = evt.data
     if evt.type == 'checkout.session.completed': _save(o)

--- a/lego/pay/pay.css
+++ b/lego/pay/pay.css
@@ -1,0 +1,26 @@
+.pay-sec { max-width: 64rem; margin: 0 auto; padding: 0 1rem 3rem; }
+
+.pay-grid { display: grid; grid-template-columns: 1fr; gap: 1.5rem; align-items: stretch; }
+@media (min-width: 768px) { .pay-grid { grid-template-columns: repeat(2, 1fr); } }
+
+.pay-card { display: flex; flex-direction: column; height: 100%; }
+.pay-card > .pay-foot { margin-top: auto; padding-top: 0.5rem; }
+.pay-price { font-size: 2.75rem; font-weight: 700; line-height: 1; letter-spacing: -0.02em; }
+.pay-price-row { display: flex; align-items: baseline; gap: 0.5rem; margin-bottom: 1rem; }
+
+.pay-perks { list-style: none; padding: 0; margin: 0 0 1.5rem; }
+.pay-perks li { display: flex; gap: 0.5rem; align-items: flex-start; padding: 0.3rem 0; font-size: 0.875rem; }
+.pay-perks svg { flex: none; margin-top: 0.15rem; color: var(--primary); }
+
+.pay-steps { display: grid; grid-template-columns: 1fr; gap: 1rem; counter-reset: paystep; }
+@media (min-width: 768px) { .pay-steps { grid-template-columns: repeat(4, 1fr); } }
+.pay-steps li { list-style: none; counter-increment: paystep; font-size: 0.875rem; }
+.pay-steps li::before { content: counter(paystep); display: block; font-family: var(--font-mono, monospace);
+  font-size: 0.75rem; color: var(--primary); border-top: 2px solid currentColor; padding-top: 0.4rem;
+  margin-bottom: 0.4rem; }
+
+.pay-tbl { width: 100%; border-collapse: collapse; font-size: 0.875rem; }
+.pay-tbl th { text-align: left; font-size: 0.7rem; letter-spacing: 0.08em; text-transform: uppercase;
+  font-weight: 500; padding-bottom: 0.5rem; border-bottom: 1px solid var(--border); }
+.pay-tbl td { padding: 0.6rem 0.75rem 0.6rem 0; border-bottom: 1px solid var(--border); }
+.pay-tbl td:first-child, .pay-tbl th:first-child { padding-left: 0; }

--- a/lego/pay/ui.py
+++ b/lego/pay/ui.py
@@ -4,7 +4,7 @@ from fasthtml.common import *
 from fastcore.all import timed_cache
 from lego.core import RouteOverrides, TextT, ButtonT, asset_css, lc_icon
 from .cfg import Routes, cfg, CATALOG
-from .data import live, sub_of
+from .data import item, live, sub_of
 
 __all__ = ['pay_head', 'pricing', 'receipt', 'money', 'mode_chip']
 
@@ -17,10 +17,15 @@ def money(cents, cur=None):
 @timed_cache(seconds=3600)
 def pay_head(): return [asset_css(Path(__file__).parent / 'pay.css')]
 
+def _chip(txt, tone, note): return Span(txt, cls=f'badge chip-{tone}'), note
+
 def mode_chip():
-    if not live(): return Span('Sandbox', cls='badge chip-yellow'), 'No Stripe key set. Orders are written to the local database so you can walk the flow.'
-    if cfg.scrt.startswith('sk_test'): return Span('Stripe test mode', cls='badge chip-blue'), 'Test key in use. Pay with card 4242 4242 4242 4242, any future expiry, any CVC.'
-    return Span('Live', cls='badge chip-green'), 'Live key in use. Cards are charged for real.'
+    'Which key the block is running on, said out loud on the page.'
+    if not live(): return _chip('Sandbox', 'yellow',
+                                'No Stripe key set. Orders are written to the local database so you can walk the flow.')
+    if cfg.scrt.startswith('sk_test'): return _chip('Stripe test mode', 'blue',
+                                                    'Test key in use. Pay with card 4242 4242 4242 4242, any future expiry, any CVC.')
+    return _chip('Live', 'green', 'Live key in use. Cards are charged for real.')
 
 def _icon(it): return lc_icon('cloud' if it.get('interval') else 'monitor', 18)
 
@@ -55,7 +60,7 @@ def _hero(err=None):
 def _owned(rows):
     if not rows: return None
     def _row(o):
-        it = next((i for i in CATALOG if i.key == o['item']), None)
+        it = item(o['item'])
         chip = 'chip-green' if o['status'] in ('paid', 'active') else 'chip-gray'
         return Tr(Td(it.nm if it else o['item']),
                   Td(money(o['amount'], o['currency']), cls='font-mono'),
@@ -78,19 +83,19 @@ _STEPS = [('Get a key', 'Create a Stripe account and copy the test secret key fr
 def _connect():
     return Section(
         Div(H2('Point it at your own account', cls='mb-2 tracking-tight'),
-            P('The catalogue is four fields per item and the prices are built inline, so nothing has to '
-              'exist in the Stripe dashboard before the first sale.', cls=f'{TextT.sm} mb-6'),
+            P('The catalogue is a list of dicts and the prices go inline on the Checkout Session, so '
+              'nothing has to exist in the Stripe dashboard before the first sale.', cls=f'{TextT.sm} mb-6'),
             Ol(*[Li(Strong(t), Br(), Span(d, cls=TextT.sm)) for t, d in _STEPS], cls='pay-steps'),
             cls='card'), cls='pay-sec')
 
-def pricing(usr=None, rows=(), err=None):
+def pricing(rows=(), err=None):
     owned = {o['item']: o for o in rows if o['status'] in ('paid', 'active')}
     return Div(_hero(err),
                Section(Div(*[_card(it, owned.get(it.key)) for it in CATALOG], cls='pay-grid'), cls='pay-sec'),
                _owned(rows), _connect())
 
 def receipt(o, usr=None):
-    it = next((i for i in CATALOG if i.key == o['item']), None)
+    it = item(o['item'])
     rows = [('Item', it.nm if it else o['item']), ('Amount', money(o['amount'], o['currency'])),
             ('Billing', 'Monthly, until you cancel' if o['sub'] else 'One payment'),
             ('Status', o['status']), ('Email', o['email'] or '—'),

--- a/lego/pay/ui.py
+++ b/lego/pay/ui.py
@@ -1,0 +1,108 @@
+from datetime import datetime
+from pathlib import Path
+from fasthtml.common import *
+from fastcore.all import timed_cache
+from lego.core import RouteOverrides, TextT, ButtonT, asset_css, lc_icon
+from .cfg import Routes, cfg, CATALOG
+from .data import live, sub_of
+
+__all__ = ['pay_head', 'pricing', 'receipt', 'money', 'mode_chip']
+
+_SYMS = dict(usd='$', eur='€', gbp='£', inr='₹', aud='A$', cad='C$')
+
+def money(cents, cur=None):
+    s, v = _SYMS.get(cur or cfg.currency, ''), cents / 100
+    return f'{s}{v:,.0f}' if cents % 100 == 0 else f'{s}{v:,.2f}'
+
+@timed_cache(seconds=3600)
+def pay_head(): return [asset_css(Path(__file__).parent / 'pay.css')]
+
+def mode_chip():
+    if not live(): return Span('Sandbox', cls='badge chip-yellow'), 'No Stripe key set. Orders are written to the local database so you can walk the flow.'
+    if cfg.scrt.startswith('sk_test'): return Span('Stripe test mode', cls='badge chip-blue'), 'Test key in use. Pay with card 4242 4242 4242 4242, any future expiry, any CVC.'
+    return Span('Live', cls='badge chip-green'), 'Live key in use. Cards are charged for real.'
+
+def _icon(it): return lc_icon('cloud' if it.get('interval') else 'monitor', 18)
+
+def _buy_btn(it, owned):
+    if owned: return A('View receipt', href=f'{Routes.done}?sid={owned["id"]}', cls=f'{ButtonT.secondary} {ButtonT.sm}')
+    # unboosted so the 303 to Stripe is a plain navigation, and so it still works with JS off
+    return Form(Button(it.cta, cls=ButtonT.primary), method='post',
+                action=Routes.buy.format(key=it.key), hx_boost='false')
+
+def _card(it, owned=None):
+    per = Span(f'/{it.interval}', cls=TextT.sm) if it.get('interval') else Span('once', cls=TextT.sm)
+    head = Div(_icon(it), Span(it.kind, cls=f'{TextT.xs} font-mono tracking-wider uppercase'),
+               Span('Owned', cls='badge chip-green') if owned else None,
+               cls='flex items-center gap-2 mb-4')
+    price = Div(Span(money(it.amount), cls='pay-price'), per, cls='pay-price-row')
+    perks = Ul(*[Li(lc_icon('check', 14), Span(p)) for p in it.perks], cls='pay-perks')
+    return Div(head, H2(it.nm, cls='mb-3 tracking-tight'), price,
+               P(it.blurb, cls=f'{TextT.sm} mb-5 leading-relaxed'), perks,
+               Div(_buy_btn(it, owned), cls='pay-foot'), cls='card pay-card')
+
+def _hero(err=None):
+    chip, note = mode_chip()
+    return Section(
+        Div(chip, Span(note, cls=TextT.sm), cls='flex items-center gap-3 mb-5'),
+        H1('Charge once, or charge every month', cls='mb-3 tracking-tight'),
+        P('Both Stripe workflows on one page. A desktop app sold outright, and a hosted service on a '
+          'monthly plan. Same block, same five routes, one field apart in the catalogue.',
+          cls='max-w-2xl leading-relaxed'),
+        P(err, cls='text-danger text-sm mt-4') if err else None,
+        cls='section-pad max-w-5xl mx-auto')
+
+def _owned(rows):
+    if not rows: return None
+    def _row(o):
+        it = next((i for i in CATALOG if i.key == o['item']), None)
+        chip = 'chip-green' if o['status'] in ('paid', 'active') else 'chip-gray'
+        return Tr(Td(it.nm if it else o['item']),
+                  Td(money(o['amount'], o['currency']), cls='font-mono'),
+                  Td(Span(o['status'], cls=f'badge {chip}')),
+                  Td(datetime.fromtimestamp(o['created_at']).strftime('%b %d, %Y'), cls=f'{TextT.xs} font-mono'),
+                  Td(A('Receipt', href=f'{Routes.done}?sid={o["id"]}', cls='underline-h')))
+    sub = sub_of(rows)
+    manage = Form(Button('Manage subscription', cls=f'{ButtonT.secondary} {ButtonT.sm}'), method='post',
+                  action=Routes.portal, hx_boost='false') if sub else None
+    return Section(H2('What you own', cls='mb-5 tracking-tight'),
+                   Table(Thead(Tr(*[Th(h) for h in ('Item', 'Paid', 'Status', 'When', '')])),
+                         Tbody(*[_row(o) for o in rows]), cls='pay-tbl mb-6'),
+                   manage, cls='pay-sec')
+
+_STEPS = [('Get a key', 'Create a Stripe account and copy the test secret key from the dashboard.'),
+          ('Set it', 'Put it in .env as STRIPE_SECRET_KEY and restart. Nothing else changes.'),
+          ('Pay', 'Card 4242 4242 4242 4242 clears every test charge Stripe will accept.'),
+          ('Forward events', 'stripe listen --forward-to localhost:5001/pay/hook, then set STRIPE_WEBHOOK_SECRET.')]
+
+def _connect():
+    return Section(
+        Div(H2('Point it at your own account', cls='mb-2 tracking-tight'),
+            P('The catalogue is four fields per item and the prices are built inline, so nothing has to '
+              'exist in the Stripe dashboard before the first sale.', cls=f'{TextT.sm} mb-6'),
+            Ol(*[Li(Strong(t), Br(), Span(d, cls=TextT.sm)) for t, d in _STEPS], cls='pay-steps'),
+            cls='card'), cls='pay-sec')
+
+def pricing(usr=None, rows=(), err=None):
+    owned = {o['item']: o for o in rows if o['status'] in ('paid', 'active')}
+    return Div(_hero(err),
+               Section(Div(*[_card(it, owned.get(it.key)) for it in CATALOG], cls='pay-grid'), cls='pay-sec'),
+               _owned(rows), _connect())
+
+def receipt(o, usr=None):
+    it = next((i for i in CATALOG if i.key == o['item']), None)
+    rows = [('Item', it.nm if it else o['item']), ('Amount', money(o['amount'], o['currency'])),
+            ('Billing', 'Monthly, until you cancel' if o['sub'] else 'One payment'),
+            ('Status', o['status']), ('Email', o['email'] or '—'),
+            ('Reference', o['id'])]
+    cta = (A('Back to pricing', href=Routes.index, cls=f'{ButtonT.secondary} {ButtonT.sm}') if usr else
+           A('Sign in to keep it', hx_get=f'{RouteOverrides.lgn}?next={Routes.index}', hx_target='body',
+             hx_swap='beforeend', cls=f'{ButtonT.primary} {ButtonT.sm}'))
+    return Section(
+        Div(Div(lc_icon('check', 20),
+                H2('Subscription started' if o['sub'] else 'Payment received', cls='m-0 tracking-tight'),
+                cls='flex items-center gap-2 mb-5'),
+            Table(Tbody(*[Tr(Td(k, cls=TextT.muted), Td(v, cls='font-mono break-words')) for k, v in rows]),
+                  cls='pay-tbl mb-6'),
+            Div(cta, cls='flex gap-3'), cls='card'),
+        cls='max-w-2xl mx-auto px-4 py-16')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
     "resend>=2.22.0",
     "rjsmin>=1.2.5",
     "ujson>=5.11.0",
+    "faststripe>=2026.5.27.2",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "email-validator>=2.3.0",
     "litesearch>=0.0.29",
     "fastlucide>=0.0.7",
+    "faststripe>=2026.5.27.2",
     "mistletoe>=1.4.0",
     "pyjwt>=2.11.0",
     "python-fasthtml>=0.14.0",
@@ -28,7 +29,6 @@ dependencies = [
     "resend>=2.22.0",
     "rjsmin>=1.2.5",
     "ujson>=5.11.0",
-    "faststripe>=2026.5.27.2",
 ]
 
 [project.scripts]

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,9 @@ LFS_PATTERNS = ['*.mp3', '*.ogg', '*.wav', '*.flac', '*.ico', '*.png', '*.jpg', 
 ENV_KEYS = dict(MODE='prod', PORT='5001', DOMAIN='lego.sankalpa.sh', HORA_DOMAIN='sankalpa.sh',
     TOKEN_EXP='691200', PURGE='false',
     JWT_SCRT=None, RESEND_API_KEY=None, WANT_GOOGLE='true', WANT_GIT='false', GOOGLE_CLI=None, GOOGLE_SCRT=None,
-    GIT_CLI=None, GIT_SCRT=None, NEED_BACKUP='false', RC_TYPE='s3', RC_PROVIDER='Cloudflare', CF_ACCESS_KEY_ID=None,
+    GIT_CLI=None, GIT_SCRT=None,
+    STRIPE_SECRET_KEY=None, STRIPE_PUBLISHABLE_KEY=None, STRIPE_WEBHOOK_SECRET=None, STRIPE_CURRENCY='usd',
+    NEED_BACKUP='false', RC_TYPE='s3', RC_PROVIDER='Cloudflare', CF_ACCESS_KEY_ID=None,
     CF_SCRT_ACCESS_KEY=None, CF_ENDPOINT=None, CF_TUNNEL_TOKEN=None, CLOUDFLARE_API_TOKEN=None, HCLOUD_TOKEN=None,
     RSYNC_FORCE='false', SERVER_NAME=None, SERVER_USER=None, SERVER_PASSWORD=None)
 

--- a/uv.lock
+++ b/uv.lock
@@ -209,6 +209,19 @@ wheels = [
 ]
 
 [[package]]
+name = "astunparse"
+version = "1.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+    { name = "wheel" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/af/4182184d3c338792894f34a62672919db7ca008c89abee9b564dd34d8029/astunparse-1.6.3.tar.gz", hash = "sha256:5ad93a8456f0d084c3456d059fd9a92cce667963232cbf763eac3bc5b7940872", size = 18290, upload-time = "2019-12-22T18:12:13.129Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/03/13dde6512ad7b4557eb792fbcf0c653af6076b81e5941d36ec61f7ce6028/astunparse-1.6.3-py2.py3-none-any.whl", hash = "sha256:c2652417f2c8b5bb325c885ae329bdf3f86424075c4fd1a128674bc6fba4b8e8", size = 12732, upload-time = "2019-12-22T18:12:11.297Z" },
+]
+
+[[package]]
 name = "async-lru"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -325,6 +338,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/78/6f/8975af88d203efd70cc69477ebac702babef38201d04621c9583f2508f25/browserforge-1.2.4.tar.gz", hash = "sha256:05686473793769856ebd3528c69071f5be0e511260993e8b2ba839863711a0c4", size = 36700, upload-time = "2026-02-03T02:52:09.721Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dd/35/ce962f738ae28ffce6293e7607b129075633e6bb185a5ab87e49246eedc2/browserforge-1.2.4-py3-none-any.whl", hash = "sha256:fb1c14e62ac09de221dcfc73074200269f697596c642cb200ceaab1127a17542", size = 37890, upload-time = "2026-02-03T02:52:08.745Z" },
+]
+
+[[package]]
+name = "build"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "os_name == 'nt'" },
+    { name = "packaging" },
+    { name = "pyproject-hooks" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
 ]
 
 [[package]]
@@ -596,7 +623,7 @@ name = "cryptography"
 version = "49.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1f/99/d1c90d6041656cc6ee229dc99cd67fd0cd5aec3c5f7d72fffc27cc750054/cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493", size = 854345, upload-time = "2026-06-12T20:02:30.512Z" }
 wheels = [
@@ -808,6 +835,19 @@ wheels = [
 ]
 
 [[package]]
+name = "execnb"
+version = "0.3.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastcore" },
+    { name = "ipython" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/c8/2ebd2be77cd8da38738971b8bc7a9041e50b9c34f1e1adf4e13130faa03d/execnb-0.3.2.tar.gz", hash = "sha256:723d01cb6388c112ad0eba1424637c105ad2fbed95c789baff7216078fae41da", size = 15787, upload-time = "2026-08-10T10:24:31.553Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a5/02/0f11fb9ee789b23fd3c3a235ea08ca9ebb80e5369a7e7849b4120a57c843/execnb-0.3.2-py3-none-any.whl", hash = "sha256:b1a9663426d8bcb795dc9d3efe14b060838dd4f3389354c228ca8aae3e4ad8f5", size = 14496, upload-time = "2026-08-10T10:24:30.294Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -868,11 +908,23 @@ wheels = [
 
 [[package]]
 name = "fastcore"
-version = "2.1.5"
+version = "2.2.12"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2c/83/81349cd1cb156b1737431ef6f3fc3065b4c2f94729bf2e10620c29c36699/fastcore-2.1.5.tar.gz", hash = "sha256:e029a2231e826c38bc02be4a179ab85737d8eeabe9c54d4f54a7ee77e721f1eb", size = 113991, upload-time = "2026-07-22T05:42:32.075Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/42/88f579378b14dfdd682e81efc17eca8ec974fe2c7fbb2427b8f11735045e/fastcore-2.2.12.tar.gz", hash = "sha256:843589e613b1b6f69dc81fedb04075a0bcea159088509f560780aef6d3528294", size = 142585, upload-time = "2026-08-12T04:10:11.161Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/d6/a660226b0770c5d4a39d5964a5e00745dc5ca25fa9d9e7948e911c30c3c3/fastcore-2.1.5-py3-none-any.whl", hash = "sha256:612a1084f039a4f65695713f62d411dfa5b9f5f4f8d767ff999b7f6c65a29bd7", size = 119006, upload-time = "2026-07-22T05:42:30.619Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/38/b039ab6965df48cb7feffb22fb2a1bfb9d20bc9ef7e46baee3c5a9e96dc6/fastcore-2.2.12-py3-none-any.whl", hash = "sha256:f926464bf4e03ea6bf4d6bb278b8d13e60c4cd52ddda277b6ef7646965f4cb37", size = 149154, upload-time = "2026-08-12T04:10:09.635Z" },
+]
+
+[[package]]
+name = "fastgit"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastcore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/40/e4/929fc011d8ed75e90cac67459707daf21dbe1037b2eafa3f6991563f6e93/fastgit-0.1.2.tar.gz", hash = "sha256:0a37a033b2d458e0f2839692ee549a9ffa1bdc1d61527af5dfc1e3a00ebfc814", size = 9380, upload-time = "2026-08-09T03:42:15.334Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/66/8f/70609f5b458842b947a2b08890f486f1adc914b66b4728a7faa5db4bd425/fastgit-0.1.2-py3-none-any.whl", hash = "sha256:990ce2843779d6353671d60d3276cb0b2d25278172d3d4902e90925a70d741f6", size = 10112, upload-time = "2026-08-09T03:42:14.35Z" },
 ]
 
 [[package]]
@@ -925,15 +977,42 @@ wheels = [
 
 [[package]]
 name = "fastspec"
-version = "0.1.2"
+version = "0.2.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "fastcore" },
-    { name = "httpx" },
+    { name = "fasttransport" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/78/48/d7655de96b1076c7efbc5fc8185b338a3c27b5b4f83aa6bc6a2dcb883ad3/fastspec-0.1.2.tar.gz", hash = "sha256:57f2450c9d81c820fb9dd9ca6281ec8addee811426fd8049bbfd816bfc872f0b", size = 27143, upload-time = "2026-07-22T15:42:08.255Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/15/be/5049770908727446414e217cf6bf24d3d64e1ee24590e0c53028d2649b50/fastspec-0.2.1.tar.gz", hash = "sha256:cea3ead207019c7338c275491178a2aff30ba6c049c0744202bc81aece2c5f13", size = 31617, upload-time = "2026-08-13T03:03:01.072Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/76/d5ebed62edf112697bfc16b398315585ac7daffd7b1951477204f742b9e2/fastspec-0.1.2-py3-none-any.whl", hash = "sha256:65fe5c6cfac585f12170098e86c973a27957e565cc005f70ec57b8fa425e419b", size = 25938, upload-time = "2026-07-22T15:42:06.831Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/68/d0b1aeb3d5caa943a3249679010823e41e55a1faa709238c8d5463072d0b/fastspec-0.2.1-py3-none-any.whl", hash = "sha256:6304129eef4cb724b43509bed5b8cf31d48aa6299a0c4d6aac9d335e19cac3a2", size = 28874, upload-time = "2026-08-13T03:02:59.829Z" },
+]
+
+[[package]]
+name = "faststripe"
+version = "2026.5.27.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastcore" },
+    { name = "fastspec" },
+    { name = "nbdev" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1d/a3/22d23039391eceaa2f513a975fdb6d809016dfd354c48aa5da1afe116d72/faststripe-2026.5.27.2.tar.gz", hash = "sha256:d4f0d7172395d0d8b7762356c1a6f3cc8a67c0aaab787ebb6ee2a40805c03472", size = 1027398, upload-time = "2026-08-13T03:16:52.184Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/85/a4/a313b266e711266a82194a7b86a5b8d68d0015130e2e8fd7b1b853d2b5e9/faststripe-2026.5.27.2-py3-none-any.whl", hash = "sha256:b8249a9eb66c7acdd36aaffc2d18753c04c40cdbddef9a9cda77d36d0af9ff1f", size = 1045590, upload-time = "2026-08-13T03:16:50.486Z" },
+]
+
+[[package]]
+name = "fasttransport"
+version = "0.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "fastcore" },
+    { name = "httpx2" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/ca/defba9b5466caafcdc069c74244c1fb27255e7c8574de523c99dec053551/fasttransport-0.0.1.tar.gz", hash = "sha256:c88fc989fb333efb4d3221379178600bac2f0c7156ad6f8d614ba7eafad39e3a", size = 9392, upload-time = "2026-08-13T03:00:45.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/68/4f69754497b13ba216e11f13d9e3d19ba9aa42c29443ddc4ba948531774d/fasttransport-0.0.1-py3-none-any.whl", hash = "sha256:ab131ac912214e1f39cba0d8fcdbf3ed26a455abb23751f5f6008c2166860d5d", size = 10135, upload-time = "2026-08-13T03:00:43.873Z" },
 ]
 
 [[package]]
@@ -1187,15 +1266,15 @@ wheels = [
 
 [[package]]
 name = "httpcore2"
-version = "2.7.0"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "h11" },
     { name = "truststore" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/fe/6a3f9f1a8bb8733326140737446aaf72fddb8b54b8f202302f5c84960613/httpcore2-2.7.0.tar.gz", hash = "sha256:6dc0fedf329a52a990930a5579edfebaea81118ea700ea0dd7de2b5e5be49efc", size = 65593, upload-time = "2026-07-14T20:40:01.111Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/6c/62e2e279e63fc4f7a5ee841ef13175a8bbc613f258e9dcc186e9de803a42/httpcore2-2.7.0-py3-none-any.whl", hash = "sha256:1452f589fe23f55b44546cd884294c41a29330af902bc0b71a761fd52d18f92b", size = 81506, upload-time = "2026-07-14T20:39:58.053Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/4f/d149104195a35e2853a2fc203a8e3477747e58c80e17dda686dace174383/httpcore2-2.10.0-py3-none-any.whl", hash = "sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01", size = 83000, upload-time = "2026-08-09T09:11:29.555Z" },
 ]
 
 [[package]]
@@ -1256,17 +1335,27 @@ socks = [
 
 [[package]]
 name = "httpx2"
-version = "2.7.0"
+version = "2.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "anyio" },
-    { name = "httpcore2" },
+    { name = "anyio", marker = "sys_platform != 'emscripten'" },
+    { name = "httpcore2", marker = "sys_platform != 'emscripten'" },
+    { name = "httpx2-jsfetch", marker = "sys_platform == 'emscripten'" },
     { name = "idna" },
-    { name = "truststore" },
+    { name = "truststore", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/4a/129b2e21b90ac2985d3928d96792bccc39bc6dfe796c5eee2d8ec06d4105/httpx2-2.7.0.tar.gz", hash = "sha256:8b30709aed5c8465b0dd3b95c09ce301c8f79e7e7a2d00ab0af551e0d0375b07", size = 94487, upload-time = "2026-07-14T20:40:02.318Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/b8/c341bba6411bdfda786020343c47a75ef472f6085caf82391b142b1a3ad9/httpx2-2.7.0-py3-none-any.whl", hash = "sha256:ed2a2719c696789e09493bd8e2bec3d8bd925cc6e26b68389ec25ade132f7bf4", size = 90234, upload-time = "2026-07-14T20:39:59.531Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/6d/a637d52449d98a6892d9a4dc0262587afdb6a66f201871842dce5a97b1c1/httpx2-2.10.0-py3-none-any.whl", hash = "sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18", size = 94355, upload-time = "2026-08-09T09:11:30.882Z" },
+]
+
+[[package]]
+name = "httpx2-jsfetch"
+version = "1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/cd/c4/0e5636363151a2a1795e0a77617168b9ca438e1748ec05fc9b5687f93d64/httpx2_jsfetch-1.0.tar.gz", hash = "sha256:70a0e3eabfef7cce5ad9c629f7d01ca05e418f586646f4ddf14782e4c1454c60", size = 6872, upload-time = "2026-08-07T00:13:07.492Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9b/43/832f631d32e4f1211caa2ba368317739fe71f0b8530e4c9d15dc454bac2a/httpx2_jsfetch-1.0-py3-none-any.whl", hash = "sha256:cb916b707601e69a07721aabc8f3f6659be3a6893bc1ff5c6f9e02241df2da32", size = 6382, upload-time = "2026-08-07T00:13:06.567Z" },
 ]
 
 [[package]]
@@ -1774,6 +1863,7 @@ dependencies = [
     { name = "diskcache" },
     { name = "email-validator" },
     { name = "fastlucide" },
+    { name = "faststripe" },
     { name = "litesearch" },
     { name = "mistletoe" },
     { name = "pyjwt" },
@@ -1801,6 +1891,7 @@ requires-dist = [
     { name = "diskcache", specifier = ">=5.6.3" },
     { name = "email-validator", specifier = ">=2.3.0" },
     { name = "fastlucide", specifier = ">=0.0.7" },
+    { name = "faststripe", specifier = ">=2026.5.27.2" },
     { name = "litesearch", specifier = ">=0.0.29" },
     { name = "mistletoe", specifier = ">=1.4.0" },
     { name = "pyjwt", specifier = ">=2.11.0" },
@@ -2186,6 +2277,27 @@ wheels = [
 ]
 
 [[package]]
+name = "nbdev"
+version = "3.3.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "asttokens" },
+    { name = "astunparse" },
+    { name = "build" },
+    { name = "execnb" },
+    { name = "fastcore" },
+    { name = "fastgit" },
+    { name = "ghapi" },
+    { name = "pyyaml" },
+    { name = "setuptools" },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/af/3d/7e8f945845c422e0300019f58772e23ea3c494b19b6eaf128b74bd7bc6eb/nbdev-3.3.12.tar.gz", hash = "sha256:0f98def38f2a6faa18cbad0bc191806c9026b7518c8814a75d8b0f3eab967da1", size = 86576, upload-time = "2026-08-12T05:25:14.621Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f6/8e/f5069978dc3af0b3c03cfeda8aa9d313bda4d9369080a27625ef71450689/nbdev-3.3.12-py3-none-any.whl", hash = "sha256:b8f0f6a8442e07674c9891a1cf3c1c1f6d18f5604eece67a3d1fb1eaff83f825", size = 91553, upload-time = "2026-08-12T05:25:13.11Z" },
+]
+
+[[package]]
 name = "nbformat"
 version = "5.10.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2504,7 +2616,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -2859,6 +2971,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
+]
+
+[[package]]
+name = "pyproject-hooks"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/82/28175b2414effca1cdac8dc99f76d660e7a4fb0ceefa4b4ab8f5f6742925/pyproject_hooks-1.2.0.tar.gz", hash = "sha256:1e859bd5c40fae9448642dd871adf459e5e2084186e8d2c2a79a824c970da1f8", size = 19228, upload-time = "2024-09-29T09:24:13.293Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/24/12818598c362d7f300f18e74db45963dbcb85150324092410c8b49405e42/pyproject_hooks-1.2.0-py3-none-any.whl", hash = "sha256:9e5c6bfa8dcc30091c74b0cf803c81fdd29d94f01992a7707bc97babb1141913", size = 10216, upload-time = "2024-09-29T09:24:11.978Z" },
 ]
 
 [[package]]
@@ -3465,8 +3586,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "cryptography" },
+    { name = "jeepney" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -3492,6 +3613,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c5/f0/184b4b5f8d00f2a92cf96eec8967a3d550b52cf94362dad1100df9e48d57/send2trash-2.1.0.tar.gz", hash = "sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459", size = 17255, upload-time = "2026-01-14T06:27:36.056Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl", hash = "sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c", size = 17610, upload-time = "2026-01-14T06:27:35.218Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "84.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/44/f5da03a8ef95d369145c5bb53050e7877c9f3d312e128605fd9504829143/setuptools-84.0.0.tar.gz", hash = "sha256:f4695c21257f0d9b537ec2692c941d02ee143b7cc1276941349a546573b2ef73", size = 1168449, upload-time = "2026-08-08T18:27:58.365Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/9c/c510029fc6ef33a6275cd2c5d3cecd6613dfd6aa401d57c54f1c18852ccf/setuptools-84.0.0-py3-none-any.whl", hash = "sha256:51a52592b3b99e102b609654876bd65f19f999935166d1352678931132b0c670", size = 818216, upload-time = "2026-08-08T18:27:56.719Z" },
 ]
 
 [[package]]
@@ -3931,6 +4061,27 @@ wheels = [
 ]
 
 [[package]]
+name = "watchdog"
+version = "6.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/db/7d/7f3d619e951c88ed75c6037b246ddcf2d322812ee8ea189be89511721d54/watchdog-6.0.0.tar.gz", hash = "sha256:9ddf7c82fda3ae8e24decda1338ede66e1c99883db93711d8fb941eaa2d8c282", size = 131220, upload-time = "2024-11-01T14:07:13.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/98/b0345cabdce2041a01293ba483333582891a3bd5769b08eceb0d406056ef/watchdog-6.0.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:490ab2ef84f11129844c23fb14ecf30ef3d8a6abafd3754a6f75ca1e6654136c", size = 96480, upload-time = "2024-11-01T14:06:42.952Z" },
+    { url = "https://files.pythonhosted.org/packages/85/83/cdf13902c626b28eedef7ec4f10745c52aad8a8fe7eb04ed7b1f111ca20e/watchdog-6.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:76aae96b00ae814b181bb25b1b98076d5fc84e8a53cd8885a318b42b6d3a5134", size = 88451, upload-time = "2024-11-01T14:06:45.084Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/c4/225c87bae08c8b9ec99030cd48ae9c4eca050a59bf5c2255853e18c87b50/watchdog-6.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a175f755fc2279e0b7312c0035d52e27211a5bc39719dd529625b1930917345b", size = 89057, upload-time = "2024-11-01T14:06:47.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/c7/ca4bf3e518cb57a686b2feb4f55a1892fd9a3dd13f470fca14e00f80ea36/watchdog-6.0.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7607498efa04a3542ae3e05e64da8202e58159aa1fa4acddf7678d34a35d4f13", size = 79079, upload-time = "2024-11-01T14:06:59.472Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/51/d46dc9332f9a647593c947b4b88e2381c8dfc0942d15b8edc0310fa4abb1/watchdog-6.0.0-py3-none-manylinux2014_armv7l.whl", hash = "sha256:9041567ee8953024c83343288ccc458fd0a2d811d6a0fd68c4c22609e3490379", size = 79078, upload-time = "2024-11-01T14:07:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/57/04edbf5e169cd318d5f07b4766fee38e825d64b6913ca157ca32d1a42267/watchdog-6.0.0-py3-none-manylinux2014_i686.whl", hash = "sha256:82dc3e3143c7e38ec49d61af98d6558288c415eac98486a5c581726e0737c00e", size = 79076, upload-time = "2024-11-01T14:07:02.568Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/cc/da8422b300e13cb187d2203f20b9253e91058aaf7db65b74142013478e66/watchdog-6.0.0-py3-none-manylinux2014_ppc64.whl", hash = "sha256:212ac9b8bf1161dc91bd09c048048a95ca3a4c4f5e5d4a7d1b1a7d5752a7f96f", size = 79077, upload-time = "2024-11-01T14:07:03.893Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/3b/b8964e04ae1a025c44ba8e4291f86e97fac443bca31de8bd98d3263d2fcf/watchdog-6.0.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:e3df4cbb9a450c6d49318f6d14f4bbc80d763fa587ba46ec86f99f9e6876bb26", size = 79078, upload-time = "2024-11-01T14:07:05.189Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ae/a696eb424bedff7407801c257d4b1afda455fe40821a2be430e173660e81/watchdog-6.0.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:2cce7cfc2008eb51feb6aab51251fd79b85d9894e98ba847408f662b3395ca3c", size = 79077, upload-time = "2024-11-01T14:07:06.376Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e8/dbf020b4d98251a9860752a094d09a65e1b436ad181faf929983f697048f/watchdog-6.0.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:20ffe5b202af80ab4266dcd3e91aae72bf2da48c0d33bdb15c66658e685e94e2", size = 79078, upload-time = "2024-11-01T14:07:07.547Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
+    { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
+    { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
 name = "watchfiles"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4096,6 +4247,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/b2/b6987faf330f5af5c787a2610124c2e8403d51724f9001ec4fff6311fe7a/websockets-16.1.1-cp314-cp314t-win32.whl", hash = "sha256:8483c2096363120eea8b07c06ae7304d520f686665fffd4811fad423930a65d7", size = 179729, upload-time = "2026-07-17T22:50:53.269Z" },
     { url = "https://files.pythonhosted.org/packages/a2/6e/fbac6ed878dd362fbad7d415fa4f84d38e3e33fed8cde45c64e783acf826/websockets-16.1.1-cp314-cp314t-win_amd64.whl", hash = "sha256:bcce07e23e5769375158f5efdcdafa8d5cd014b93c6683865b840ed65b96f231", size = 180072, upload-time = "2026-07-17T22:50:54.969Z" },
     { url = "https://files.pythonhosted.org/packages/be/4d/2d0d67834092e354d2b0498f014a41249a89556bc406cf86f3e1557bb463/websockets-16.1.1-py3-none-any.whl", hash = "sha256:6abbd3e82c731c8e531714466acd5d87b5e88ac3243465337ba71d68e23ae7e3", size = 173814, upload-time = "2026-07-17T22:51:04.184Z" },
+]
+
+[[package]]
+name = "wheel"
+version = "0.48.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d0/20/50ed6bdf27dec98b568a8ae25dc599f35baa3d9709f9e83fd1edb56b9a90/wheel-0.48.0.tar.gz", hash = "sha256:94800765601e9171bf5d58d066e640662842bcedcbab982b2c90787a2c987322", size = 66471, upload-time = "2026-08-11T22:02:27.327Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/29/69cfbb602cd91690c55d38ba9fe53e6a7e76a6fa647bf38f19c138d25449/wheel-0.48.0-py3-none-any.whl", hash = "sha256:3217dcc807155e45db462d7ef2431f5ddda0d7273b700d05a67b271ceb1287ab", size = 33320, upload-time = "2026-08-11T22:02:26.1Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
A new block, `lego/pay/`, that sells things with Stripe through [faststripe](https://github.com/AnswerDotAI/faststripe). It covers both workflows: a desktop app at $200 paid once, and a hosted service at $19 a month. Five routes, one table, one stylesheet, and nothing that has to be set up in the Stripe dashboard first.

## The block

`lego/pay/` follows the block layout: `cfg.py` (routes and catalogue), `data.py` (table and Stripe calls), `ui.py` (page), `app.py` (handlers and `connect`), plus its own `pay.css`. Wired into `lego/app.py` before auth, so its routes reach the skip list in time.

| route | purpose |
|---|---|
| `GET /pay` | catalogue, plus what the signed-in reader owns |
| `POST /pay/buy/{key}` | opens a Checkout Session, 303s to Stripe |
| `GET /pay/done?sid=` | reads the session, writes the order, renders the receipt |
| `POST /pay/portal` | 303s a subscriber to Stripe's billing portal |
| `POST /pay/hook` | signed webhook |

Three decisions worth calling out:

**Prices go inline.** `line_items[].price_data` carries the amount and, for subscriptions, the `recurring` interval. No products or prices exist in the dashboard, so carrying the block to another app is a copy of the folder and an edit to `CATALOG`.

**`/pay/done` reads the session rather than waiting for the webhook.** Webhooks need a public URL and a signing secret. Reading the returned session needs neither, so a bare test key records a sale and shows a receipt. The webhook then writes the same row again, and is what catches the renewals and cancellations that happen with nobody on the site.

**No key means sandbox.** With `STRIPE_SECRET_KEY` unset, `buy()` writes the row Stripe would have returned and redirects to the receipt. Every page works before you have an account, and the pricing page says which key it is running on.

## Screenshots

Pricing page, no key set. The chip and the note say so.

[Pricing page in sandbox mode](https://cursor.com/agents/bc-dc909207-c5b2-495e-b131-3065389d66a3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fpay-pricing.png)

Signed in, after buying both. The cards flip to Owned, the table lists the orders, and the subscription gets a billing-portal button.

[Pricing page for a buyer who owns both items](https://cursor.com/agents/bc-dc909207-c5b2-495e-b131-3065389d66a3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fpay-owned.png)

Receipts. The heading changes with the mode.

[Receipt for the one-off payment](https://cursor.com/agents/bc-dc909207-c5b2-495e-b131-3065389d66a3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fpay-receipt.png)

[Receipt for the subscription](https://cursor.com/agents/bc-dc909207-c5b2-495e-b131-3065389d66a3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fpay-receipt-sub.png)

With `STRIPE_SECRET_KEY=sk_test_...` set, the chip changes and the page hands over the test card number.

[Pricing page with a test key set](https://cursor.com/agents/bc-dc909207-c5b2-495e-b131-3065389d66a3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fpay-testmode.png)

The key above is not a real one, which is how the error path got its screenshot: the button called `api.stripe.com`, Stripe answered 401, and the block put it on the page.

[Stripe 401 surfaced on the pricing page](https://cursor.com/agents/bc-dc909207-c5b2-495e-b131-3065389d66a3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fpay-stripe-error.png)

Mobile.

[Pricing page at 414px](https://cursor.com/agents/bc-dc909207-c5b2-495e-b131-3065389d66a3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fpay-mobile.png)

The rest of the app, unchanged apart from the new Pricing pill in the navbar.

[Blog index](https://cursor.com/agents/bc-dc909207-c5b2-495e-b131-3065389d66a3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fhome-blog.png)

[Dashboards index](https://cursor.com/agents/bc-dc909207-c5b2-495e-b131-3065389d66a3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdash.png)

## How it was tested

- Sandbox flow end to end in a browser: buy, receipt, sign in, buy both, owned list, billing-portal button.
- Real Stripe API surface via `stripe-mock`: Checkout Sessions in both modes, session retrieval, billing portal session.
- Real `api.stripe.com` with a bogus test key: the 401 reaches the page rather than a 500.
- Webhooks with HMAC-signed payloads: `checkout.session.completed` writes the order, `customer.subscription.deleted` flips the row to `canceled`, a bad signature gets 400, and a missing `stripe-signature` header gets 400 rather than an `AttributeError`.
- Every existing route still renders: `/`, `/blog`, `/dash`, `/dash/{db}`, `/dash/chart.json`, `/hora`, `/health`.

## Docs

`README.md` gets a Payments section: sandbox, test key, `stripe listen` for webhooks, going live, the env var table, the catalogue shape, and how to carry the block elsewhere. `SKILL.md` gets a Pay block section and the four new env vars. `setup.py` adds the Stripe keys to `ENV_KEYS`, so `lego-push` routes them to GitHub secrets and the deploy workflow picks them up.

Prose checked with [slopometer](https://github.com/AnswerDotAI/slopometer). The new README section scores 3.0 density, worst finding 3; the README as a whole moves from 35.3 to 24.1.

## Lean pass

Beyond the block: dropped a debug `print` on every failed registration in `lego/auth/data.py`, a redundant explicit import line in `lego/app.py` shadowed by the `import *` on the next line, and unused imports in `lego/dash/{app,build,ui}.py`.

## Dependency note

`faststripe` pulls `fastcore` to 2.2.12 and `fastspec` to 0.2.1. The app runs on both.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc909207-c5b2-495e-b131-3065389d66a3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc909207-c5b2-495e-b131-3065389d66a3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

